### PR TITLE
ship -> macro name change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Tuition DApp
 
-Live on [tuition.shipyard.xyz](https://tuition.shipyard.xyz)!
+Live on [tuition.0xmacro.com](https://tuition.0xmacro.com)!
 
 ## Functionality
 
-This dapp connects to the deployed tuition smart contract, allowing Shipyard's students to deposit their 1 ETH payment, and according to the outcomes, getting refunded or moving to the DAO's treasury.
+This dapp connects to the deployed tuition smart contract, allowing Macro's students to deposit their 1 ETH payment, and according to the outcomes, getting refunded or moving to the DAO's treasury.
 
 ## Pricing display
 

--- a/components/Landing.tsx
+++ b/components/Landing.tsx
@@ -19,7 +19,7 @@ const Landing = () => {
           fontSize={{ base: "3xl", md: "5xl" }}
           lineHeight={{ base: "2.8rem", md: "5rem" }}
         >
-          Shipyard School
+          Macro School
         </Text>
         <Text
           mt="4"

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -22,7 +22,7 @@ const Navbar = () => {
       userSelect="none"
     >
       <Text fontSize="2xl" fontWeight="bold" color="gray.100">
-        SHIPYARD
+        MACRO
       </Text>
       <Flex>
         <Button action={handleWalletConnect}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,7 +12,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
-        <title>Shipyard Tuition</title>
+        <title>Macro Tuition</title>
         <link
           rel="stylesheet"
           href="//cdn.jsdelivr.net/npm/hack-font@3.3.0/build/web/hack-subset.css"


### PR DESCRIPTION
Should be merged _after_ the switch from tuition.shipyard.xyz ->
tuition.0xmacro.com